### PR TITLE
Busy indicator on login

### DIFF
--- a/.idea/.idea.MattEland.DigitalDungeonMaster/.idea/avalonia.xml
+++ b/.idea/.idea.MattEland.DigitalDungeonMaster/.idea/avalonia.xml
@@ -4,6 +4,7 @@
     <option name="projectPerEditor">
       <map>
         <entry key="MattEland.DigitalDungeonMaster.AvaloniaApp/App.axaml" value="MattEland.DigitalDungeonMaster.AvaloniaApp/MattEland.DigitalDungeonMaster.AvaloniaApp.csproj" />
+        <entry key="MattEland.DigitalDungeonMaster.AvaloniaApp/BusySpinner.axaml" value="MattEland.DigitalDungeonMaster.AvaloniaApp/MattEland.DigitalDungeonMaster.AvaloniaApp.csproj" />
         <entry key="MattEland.DigitalDungeonMaster.AvaloniaApp/Views/HomePageView.axaml" value="MattEland.DigitalDungeonMaster.AvaloniaApp/MattEland.DigitalDungeonMaster.AvaloniaApp.csproj" />
         <entry key="MattEland.DigitalDungeonMaster.AvaloniaApp/Views/LoginView.axaml" value="MattEland.DigitalDungeonMaster.AvaloniaApp/MattEland.DigitalDungeonMaster.AvaloniaApp.csproj" />
         <entry key="MattEland.DigitalDungeonMaster.AvaloniaApp/Views/MainWindow.axaml" value="MattEland.DigitalDungeonMaster.AvaloniaApp/MattEland.DigitalDungeonMaster.AvaloniaApp.csproj" />

--- a/MattEland.DigitalDungeonMaster.AvaloniaApp/App.axaml
+++ b/MattEland.DigitalDungeonMaster.AvaloniaApp/App.axaml
@@ -3,9 +3,12 @@
              x:Class="MattEland.DigitalDungeonMaster.AvaloniaApp.App"
              xmlns:local="using:MattEland.DigitalDungeonMaster.AvaloniaApp"
              xmlns:semi="https://irihi.tech/semi"
+             xmlns:converters="clr-namespace:MattEland.DigitalDungeonMaster.AvaloniaApp.Converters"
              RequestedThemeVariant="Default">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
-
+    <Application.Resources>
+        <converters:InverseBooleanConverter x:Key="InverseBooleanConverter"/>        
+    </Application.Resources>
     <Application.DataTemplates>
         <local:ViewLocator/>
     </Application.DataTemplates>

--- a/MattEland.DigitalDungeonMaster.AvaloniaApp/Converters/InverseBooleanConverter.cs
+++ b/MattEland.DigitalDungeonMaster.AvaloniaApp/Converters/InverseBooleanConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace MattEland.DigitalDungeonMaster.AvaloniaApp.Converters;
+
+public class InverseBooleanConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+        {
+            return !b;
+        }
+
+        return value;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+        {
+            return !b;
+        }
+
+        return value;
+    }
+}

--- a/MattEland.DigitalDungeonMaster.AvaloniaApp/MattEland.DigitalDungeonMaster.AvaloniaApp.csproj
+++ b/MattEland.DigitalDungeonMaster.AvaloniaApp/MattEland.DigitalDungeonMaster.AvaloniaApp.csproj
@@ -37,4 +37,11 @@
     <ItemGroup>
       <AdditionalFiles Include="Pages\LoginPage.axaml" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Compile Update="Controls\BusySpinner.axaml.cs">
+        <DependentUpon>BusySpinner.axaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+    </ItemGroup>
 </Project>

--- a/MattEland.DigitalDungeonMaster.AvaloniaApp/Pages/LoginPage.axaml
+++ b/MattEland.DigitalDungeonMaster.AvaloniaApp/Pages/LoginPage.axaml
@@ -3,31 +3,39 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:MattEland.DigitalDungeonMaster.AvaloniaApp.ViewModels"
+             xmlns:widgets="clr-namespace:MattEland.DigitalDungeonMaster.AvaloniaApp.Widgets"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
              x:DataType="vm:LoginViewModel"
              x:Class="MattEland.DigitalDungeonMaster.AvaloniaApp.Pages.LoginPage">
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" MinWidth="200" Spacing="16">
-        <StackPanel Orientation="Vertical" Spacing="4">
-            <Label Target="Username" HorizontalAlignment="Left">Username</Label>
-            <TextBox HorizontalAlignment="Stretch" Name="Username" Text="{Binding Path=Username}" AttachedToVisualTree="FocusDefaultControl"
-                     ToolTip.Tip="The username you registered under. This is likely your email address."/>
+    <Grid>
+        <widgets:BusySpinner IsVisible="{Binding IsBusy}" />
+        <StackPanel Orientation="Vertical" Spacing="16" 
+                    HorizontalAlignment="Center" VerticalAlignment="Center" 
+                    IsEnabled="{Binding IsBusy, Converter={StaticResource InverseBooleanConverter}}"
+                    MinWidth="200">
+            <StackPanel Orientation="Vertical" Spacing="4">
+                <Label Target="Username" HorizontalAlignment="Left">Username</Label>
+                <TextBox HorizontalAlignment="Stretch" Name="Username" Text="{Binding Path=Username}"
+                         AttachedToVisualTree="FocusDefaultControl"
+                         ToolTip.Tip="The username you registered under. This is likely your email address." />
+            </StackPanel>
+
+            <StackPanel Orientation="Vertical" Spacing="4">
+                <Label Target="Password" HorizontalAlignment="Left">Password</Label>
+                <TextBox Name="Password" Text="{Binding Path=Password}" PasswordChar="*"
+                         ToolTip.Tip="Your password. There is no current way of resetting your password." />
+            </StackPanel>
+
+            <Button HorizontalAlignment="Right"
+                    IsDefault="True"
+                    ToolTip.Tip="Log in with the specified username and password"
+                    Classes="Primary Large"
+                    Theme="{DynamicResource OutlineButton}"
+                    Command="{Binding Path=LoginCommand}"
+                    CommandParameter="{Binding}">
+                Login
+            </Button>
         </StackPanel>
-        
-        <StackPanel Orientation="Vertical" Spacing="4">
-            <Label Target="Password" HorizontalAlignment="Left">Password</Label>
-            <TextBox Name="Password" Text="{Binding Path=Password}" PasswordChar="*" 
-                     ToolTip.Tip="Your password. There is no current way of resetting your password."/>
-        </StackPanel>
-        
-        <Button HorizontalAlignment="Right"
-                IsDefault="True"
-                ToolTip.Tip="Log in with the specified username and password"
-                Classes="Primary Large"
-                Theme="{DynamicResource OutlineButton}"
-                Command="{Binding Path=LoginCommand}"
-                CommandParameter="{Binding}">
-            Login
-        </Button>
-    </StackPanel>
+    </Grid>
 </UserControl>

--- a/MattEland.DigitalDungeonMaster.AvaloniaApp/Widgets/BusySpinner.axaml
+++ b/MattEland.DigitalDungeonMaster.AvaloniaApp/Widgets/BusySpinner.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="MattEland.DigitalDungeonMaster.AvaloniaApp.Widgets.BusySpinner">
+    <ProgressBar
+        Width="100"
+        Height="100"
+        Classes="Primary"
+        IsIndeterminate="True"
+        Maximum="100"
+        Minimum="0"
+        Theme="{DynamicResource ProgressRing}"
+        ShowProgressText="False"/>
+</UserControl>

--- a/MattEland.DigitalDungeonMaster.AvaloniaApp/Widgets/BusySpinner.axaml.cs
+++ b/MattEland.DigitalDungeonMaster.AvaloniaApp/Widgets/BusySpinner.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace MattEland.DigitalDungeonMaster.AvaloniaApp.Widgets;
+
+public partial class BusySpinner : UserControl
+{
+    public BusySpinner()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Adds busy indicator support and uses it on the login page. This may need to move app-wide, but for now it can live on each page.